### PR TITLE
Document support for enum options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ class ContactInfo < ActiveRecord::Base
 end
 ```
 
+Additionally, `enum` options are fully supported, for example
+```ruby
+class User < ActiveRecord::Base
+  include PGEnum(status: %w[active inactive deleted], _prefix: 'user', _suffix: true)
+end
+```
+
+is equivalent to
+```ruby
+class User < ActiveRecord::Base
+  enum status: { active: 'active', inactive: 'inactive', deleted: 'deleted' }, _prefix: 'user', _suffix: true
+end
+```
+
 There's no technical reason why you couldn't detect enum columns at startup time and automatically do this wireup, but I feel that the benefit of self-documenting outweighs the convenience.
 
 ## Development

--- a/spec/active_record/pg_enum_spec.rb
+++ b/spec/active_record/pg_enum_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe ActiveRecord::PGEnum do
       expect(TestTable).to respond_to :foo_types
       expect(TestTable.foo_types).to match({ "bar" => "bar", "baz" => "baz" })
     end
+
+    it "passes any additional options to ::enum", version: ">= 5.0" do
+      expect(TestTable).to receive(:enum).with(foo_type: { bar: "bar", baz: "baz" }, _prefix: true, _suffix: 'fizz').and_call_original
+
+      TestTable.include PGEnum(foo_type: %i[bar baz], _prefix: true, _suffix: 'fizz')
+
+      expect(TestTable).to respond_to :foo_type_bar_fizz
+      expect(TestTable.new).to respond_to :foo_type_bar_fizz?
+      expect(TestTable.new).to respond_to :foo_type_baz_fizz!
+    end
   end
 end


### PR DESCRIPTION
After posting https://github.com/alassek/activerecord-pg_enum/issues/5 I did some digging and discovered that the gem does support enum options :man_facepalming: 

I've added a test covering this functionality and updated the README with an example

closes https://github.com/alassek/activerecord-pg_enum/issues/5