### PR TITLE
Don't include schema name in dumped enum types to be consistent with the way tables are dumped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Don't include schema name in dumped enum types to be consistent with the way tables are dumped
 
 ## [1.0.4] - 2019-11-16
 ### Fixed

--- a/Rakefile
+++ b/Rakefile
@@ -10,14 +10,8 @@ end
 
 task :connection do
   require "active_record"
-
-  ActiveRecord::Base.establish_connection(
-    adapter:  "postgresql",
-    host:     ENV.fetch("PGHOST", "localhost"),
-    port:     ENV.fetch("PGPORT", "5432"),
-    username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
-    password: ENV["TEST_PASSWORD"]
-  )
+  require_relative "spec/support/connection_config"
+  ActiveRecord::Base.establish_connection(db_config.except(:database))
 end
 
 namespace :spec do

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ task :connection do
 
   ActiveRecord::Base.establish_connection(
     adapter:  "postgresql",
+    host:     ENV.fetch("PGHOST", "localhost"),
     port:     ENV.fetch("PGPORT", "5432"),
     username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
     password: ENV["TEST_PASSWORD"]

--- a/spec/active_record/connection_adapters/postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/postgresql_adapter_spec.rb
@@ -24,8 +24,13 @@ RSpec.describe "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter" do
       execute "DROP SCHEMA custom_namespace"
     end
 
+    it "is looking at the expected schemas from search path" do
+      expect(connection.schema_search_path).to eq "public, custom_namespace"
+      expect(connection.select_values('select current_schemas(false)')).to eq ["{public,custom_namespace}"]
+    end
+
     it "lists types in alphabetical order" do
-      expect(subject.enum_types.keys).to eq %w[bar_type baz_type custom_namespace.status_type foo_bar_type quux_type]
+      expect(subject.enum_types.keys).to eq %w[bar_type baz_type foo_bar_type quux_type status_type]
     end
 
     it "deserializes the types correctly" do

--- a/spec/support/connection.rb
+++ b/spec/support/connection.rb
@@ -1,14 +1,4 @@
 require "active_record"
-
-def db_config
-  {
-    adapter: "postgresql",
-    host:     ENV.fetch("PGHOST", "localhost"),
-    port:     ENV.fetch("PGPORT", "5432"),
-    database: ENV.fetch("TEST_DATABASE", "pg_enum_test"),
-    username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
-    password: ENV["TEST_PASSWORD"]
-  }
-end
+require_relative "connection_config"
 
 ActiveRecord::Base.establish_connection(db_config)

--- a/spec/support/connection.rb
+++ b/spec/support/connection.rb
@@ -3,6 +3,8 @@ require "active_record"
 def db_config
   {
     adapter: "postgresql",
+    host:     ENV.fetch("PGHOST", "localhost"),
+    port:     ENV.fetch("PGPORT", "5432"),
     database: ENV.fetch("TEST_DATABASE", "pg_enum_test"),
     username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
     password: ENV["TEST_PASSWORD"]

--- a/spec/support/connection_config.rb
+++ b/spec/support/connection_config.rb
@@ -5,6 +5,7 @@ def db_config
     port:     ENV.fetch("PGPORT", "5432"),
     database: ENV.fetch("TEST_DATABASE", "pg_enum_test"),
     username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
-    password: ENV["TEST_PASSWORD"]
+    password: ENV["TEST_PASSWORD"],
+    schema_search_path: 'public, custom_namespace'
   }
 end

--- a/spec/support/connection_config.rb
+++ b/spec/support/connection_config.rb
@@ -1,0 +1,10 @@
+def db_config
+  {
+    adapter: "postgresql",
+    host:     ENV.fetch("PGHOST", "localhost"),
+    port:     ENV.fetch("PGPORT", "5432"),
+    database: ENV.fetch("TEST_DATABASE", "pg_enum_test"),
+    username: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") },
+    password: ENV["TEST_PASSWORD"]
+  }
+end


### PR DESCRIPTION
Fixes #8 