### PR TITLE
Ensure we don't modify `Gem::Version` internals when installing

### DIFF
--- a/lib/active_record/pg_enum.rb
+++ b/lib/active_record/pg_enum.rb
@@ -45,7 +45,7 @@ module ActiveRecord
       end
 
       def approximate_version(version)
-        segments = version.respond_to?(:canonical_segments) ? version.canonical_segments : version.segments
+        segments = version.respond_to?(:canonical_segments) ? version.canonical_segments.dup : version.segments
 
         segments.pop     while segments.any? { |s| String === s }
         segments.pop     while segments.size > 2


### PR DESCRIPTION
[`Gem::Version#canonical_segments`](https://github.com/rubygems/rubygems/blob/v3.2.4/lib/rubygems/version.rb#L371-L376) memoizes the array, which is different than [`segments`](https://github.com/rubygems/rubygems/blob/v3.2.4/lib/rubygems/version.rb#L319-L321), which returns a `dup`.

Since we are manipulating the array to do this calculation, we should not modify `canonical_segments` itself.

I ran into this since `Gem::Version` objects are essentially value objects, cached across the system based on the string:

```ruby
Gem::Version.new('6.0.3.4') === Gem::Version.new('6.0.3.4')
# => true
```

Because of that, when doing my own inspection of `Rails.gem_version.canonical_segments` after activerecord-pg_enum had been `install`ed, the `canonical_segments` array had been modified.

Consider this scenario:

```ruby
Rails.gem_version
# => #<Gem::Version "6.0.3.4">
Rails.gem_version.canonical_segments
# => [6, 0, 3, 4]
Rails.gem_version > Gem::Version.new('6.0')
# => true
# activerecord-pg_enum is installed
Rails.gem_version.canonical_segments
# => [6, 0]
Rails.gem_version > Gem::Version.new('6.0')
# => false
```