### PR TITLE
A simpler helper called `inferred_enum`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ ActiveRecord::Schema.define(version: 2019_06_19_214914) do
   enable_extension "plpgsql"
 
   create_enum "status_type", %w[new pending active archived]
-  
-  create_table "orders", id: :serial, force: :cascade do |t|
-    t.enum "status", as: "status_type", default: "new"
+
+  create_table :orders, id: :serial, force: :cascade do |t|
+    t.enum :status, as: :status_type, default: :new
   end
 
 end
@@ -82,11 +82,11 @@ Defining a new ENUM
 ```ruby
 class AddContactMethodType < ActiveRecord::Migration[5.2]
   def up
-    create_enum "contact_method_type", %w[Email Phone]
+    create_enum :contact_method_type, %w[Email Phone]
   end
 
   def down
-    drop_enum "contact_method_type"
+    drop_enum :contact_method_type
   end
 end
 ```
@@ -111,7 +111,7 @@ Adding an enum column to a table
 class AddStatusToOrder < ActiveRecord::Migration[5.2]
   def change
     change_table :orders do |t|
-      t.enum :status, as: "status_type", default: "new"
+      t.enum :status, as: :status_type, default: 'new'
     end
   end
 end
@@ -122,7 +122,7 @@ Renaming an enum type
 ```ruby
 class RenameStatusType < ActiveRecord::Migration[6.0]
   def change
-    rename_enum "status_type", to: "order_status_type"
+    rename_enum :status_type, to: :order_status_type
   end
 end
 ```
@@ -138,7 +138,7 @@ Changing an enum label
 ```ruby
 class ChangeStatusHoldLabel < ActiveRecord::Migration[6.0]
   def change
-    rename_enum_value "status_type", from: "on hold", to: "OnHold"
+    rename_enum_value :status_type, from: 'on hold', to: 'OnHold'
   end
 end
 ```
@@ -149,6 +149,7 @@ ALTER TYPE status_type RENAME VALUE 'on hold' TO 'OnHold';
 
 ### Module Builder
 
+You can specify the values
 ```ruby
 class ContactInfo < ActiveRecord::Base
   include PGEnum(contact_method: %w[Email SMS Phone])
@@ -177,7 +178,21 @@ class User < ActiveRecord::Base
 end
 ```
 
-There's no technical reason why you couldn't detect enum columns at startup time and automatically do this wireup, but I feel that the benefit of self-documenting outweighs the convenience.
+Alternatively values can be infered from the enum values using the `postgres_enum` helper, which can be helpful for readability especially if the type contains a large number of values.
+
+For example:
+```ruby
+class ContactInfo < ActiveRecord::Base
+  postgres_enum :contact_method, :contact_method_type
+end
+```
+
+assuming `contact_info_type` constains `Email, SMS, Phone1`, this is equivelent to
+```ruby
+class ContactInfo < ActiveRecord::Base
+  enum contact_method: { Email: "Email", SMS: "SMS", Phone: "Phone" }
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ class User < ActiveRecord::Base
 end
 ```
 
-Alternatively values can be infered from the enum values using the `postgres_enum` helper, which can be helpful for readability especially if the type contains a large number of values.
+Alternatively values can be inferred from the enum values using the `inferred_enum` helper, which can be helpful for readability especially if the type contains a large number of values.
 
 For example:
 ```ruby
 class ContactInfo < ActiveRecord::Base
-  postgres_enum :contact_method, :contact_method_type
+  inferred_enum :contact_method, :contact_method_type
 end
 ```
 
@@ -196,7 +196,9 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `appraisal rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. You will need a database user specified by the DB_USER (defaults to `pg_enum`) environment variable with CREATEDB permissions.
+
+Run `appraisal rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 Test a specific version with `appraisal 6.0 rake spec`. This is usually necessary because different versions have different Ruby version support.
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 task :connection do
   require "active_record"
   require_relative "spec/support/connection_config"
-  ActiveRecord::Base.establish_connection(db_config.except(:database))
+  ActiveRecord::Base.establish_connection db_config.merge(database: 'template1')
 end
 
 namespace :spec do
@@ -20,14 +20,14 @@ namespace :spec do
   desc "Setup the Database for testing"
   task setup: [:connection] do
     ActiveRecord::Base.connection_pool.with_connection do |conn|
-      conn.create_database ENV.fetch("TEST_DATABASE", "pg_enum_test"), owner: ENV.fetch("TEST_USER") { ENV.fetch("USER", "pg_enum") }
+      conn.create_database db_config[:database], owner: db_config[:username]
     end
   end
 
   desc "Discard the test database"
   task teardown: [:connection] do
     ActiveRecord::Base.connection_pool.with_connection do |conn|
-      conn.drop_database ENV.fetch("TEST_DATABASE", "pg_enum_test")
+      conn.drop_database db_config[:database]
     end
   end
 end

--- a/spec/support/connection_config.rb
+++ b/spec/support/connection_config.rb
@@ -1,5 +1,5 @@
 def db_config
-  {
+  @db_config ||= {
     adapter: "postgresql",
     host:     ENV.fetch("PGHOST", "localhost"),
     port:     ENV.fetch("PGPORT", "5432"),


### PR DESCRIPTION
Allows for an optional use of a simpler helper for postgres enums that infers the values from the database.