### PR TITLE
Update README regarding add_enum_value in transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ class AddContactMethodType < ActiveRecord::Migration[5.2]
 end
 ```
 
-Adding a value to an existing ENUM (you must disable the wrapping transaction)
+Adding a value to an existing ENUM (you must disable the wrapping transaction on PostgreSQL versions older than 12)
 
 ```ruby
 class AddSMSToContactMethodType < ActiveRecord::Migration[5.2]


### PR DESCRIPTION
Postgres 12 relaxed the requirements around ALTER TYPE in transactions:

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=212fab9926b2f0f04b0187568e7124b70e8deee5
